### PR TITLE
Fix link to JS snippets

### DIFF
--- a/web_assets/packages/js_snippets/README.md
+++ b/web_assets/packages/js_snippets/README.md
@@ -1,3 +1,3 @@
 # js_snippets
 
-Demonstrates usage of the [wasm-bindgen JS snippets](https://rustwasm.github.io/wasm-bindgen/reference/js-snippets.html) feature.
+Demonstrates usage of the [wasm-bindgen JS snippets](https://wasm-bindgen.github.io/wasm-bindgen/reference/js-snippets.html) feature.


### PR DESCRIPTION
I was going through the changelog and noticed this link is now dead, since the Rust WASM org has been archived and `wasm-bindgen` has [moved to a new org and website](https://github.com/wasm-bindgen).

Cheers! :)